### PR TITLE
Yml fix for phpBB3.3.x

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -2,23 +2,23 @@ services:
     tas2580.seourls.base:
         class: tas2580\seourls\event\base
         arguments:
-            - @auth
-            - @config
-            - %core.root_path%
+            - '@auth'
+            - '@config'
+            - '%core.root_path%'
     tas2580.seourls.listener:
         class: tas2580\seourls\event\listener
         arguments:
-            - @tas2580.seourls.base
-            - @template
-            - @request
-            - @path_helper
-            - %core.root_path%
-            - %core.php_ext%
+            - '@tas2580.seourls.base'
+            - '@template'
+            - '@request'
+            - '@path_helper'
+            - '%core.root_path%'
+            - '%core.php_ext%'
         tags:
             - { name: event.listener }
     tas2580.seourls.extensions:
         class: tas2580\seourls\event\extensions
         arguments:
-            - @tas2580.seourls.base
+            - '@tas2580.seourls.base'
         tags:
             - { name: event.listener }


### PR DESCRIPTION
Fix for https://github.com/tas2580/seourls/issues/63

The file "/data/www/avrotros.nl/opgelicht/phpBB3.3.0/ext/tas2580/seourls/config/services.yml" does not contain valid YAML: The reserved indicator "@" cannot start a plain scalar; you need to quote the scalar at line 5 (near "- @auth").